### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ Milkdown provides the following official plugins:
 -   [milkdown-lab](https://github.com/enpitsuLin/milkdown-lab)
 
     Unofficial plugins collection for milkdown.
+  
+-   [coditor](https://github.com/jiannei/coditor)
+
+    Another unofficial plugins collection for milkdown, including placeholder、shiki、remoteUploader, etc.
+
 
 ## Apps & Integrations
 -   [milkdown-vscode](https://github.com/Saul-Mirone/milkdown-vscode)


### PR DESCRIPTION
A collection of plugins support Milkdown v7 version, including placeholder, shiki, and remoteUploader.